### PR TITLE
Remove "homepage" property from manifest

### DIFF
--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -4,7 +4,6 @@
     "runtime-version": "3.28",
     "sdk": "org.gnome.Sdk",
     "command": "dropbox-app",
-    "homepage": "https://www.dropbox.com",
     "cleanup": [
         "/lib/debug"
     ],


### PR DESCRIPTION
This is not known to flatpak-builder, not mentioned in the documentation, and not found in any other manifests I can find.