### PR TITLE
launcher: don't show Dropbox folder when autostarted

### DIFF
--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -16,6 +16,21 @@
     ],
     "modules": [
         {
+            "name": "python3-psutil",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/giampaolo/psutil/archive/release-5.4.5.tar.gz",
+                    "sha256": "5bf25eff39ba5ba1d00dc94d114012d11b7a6ace62d98943897097d117e0a3f6"
+                }
+            ],
+            "build-commands": [
+                "python3 setup.py build",
+                "python3 setup.py install --prefix /app"
+            ]
+        },
+        {
             "name": "dropbox-app",
             "buildsystem": "simple",
             "sources": [
@@ -71,21 +86,6 @@
                 "install -m644 com.dropbox.Client.desktop /app/share/applications/com.dropbox.Client.desktop",
 
                 "for icon_size in 16 22 24 32 48 64 256; do install -d /app/share/icons/hicolor/${icon_size}x${icon_size}/apps; install -m644 dropbox_${icon_size}.png /app/share/icons/hicolor/${icon_size}x${icon_size}/apps/com.dropbox.Client.png; done"
-            ]
-        },
-        {
-            "name": "python3-psutil",
-            "buildsystem": "simple",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/giampaolo/psutil/archive/release-5.4.5.tar.gz",
-                    "sha256": "5bf25eff39ba5ba1d00dc94d114012d11b7a6ace62d98943897097d117e0a3f6"
-                }
-            ],
-            "build-commands": [
-                "python3 setup.py build",
-                "python3 setup.py install --prefix /app"
             ]
         },
         {

--- a/dropbox-app.py
+++ b/dropbox-app.py
@@ -285,7 +285,8 @@ class DropboxLauncher():
         self._open_dropbox_directory()
         self._dir_monitor.cancel()
 
-if __name__ == '__main__':
+
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--debug', dest='debug', action='store_true')
 
@@ -295,3 +296,6 @@ if __name__ == '__main__':
 
     is_autostarted = 'DESKTOP_AUTOSTART_ID' in os.environ
     DropboxLauncher(silent=is_autostarted).run()
+
+if __name__ == '__main__':
+    main()

--- a/dropbox-app.py
+++ b/dropbox-app.py
@@ -123,14 +123,14 @@ def get_dropbox_directory():
 
 
 class DropboxLauncher():
-
-    def __init__(self):
+    def __init__(self, silent):
         self._mainloop = GLib.MainLoop()
         self._config_monitor = None
         self._dir_monitor = None
         self._bus_owner_id = 0
         self._quit_if_name_lost = False
         self._launcher = None
+        self._silent = silent
 
     def run(self):
         self._try_own_bus_name()
@@ -189,6 +189,10 @@ class DropboxLauncher():
         sys.exit(retcode)
 
     def _open_dropbox_directory(self):
+        if self._silent:
+            logging.info("Autostarted; not opening Dropbox directory")
+            return
+
         directory = get_dropbox_directory()
         logging.info("Attempting to open Dropbox directory at {}...".format(directory))
 
@@ -289,4 +293,5 @@ if __name__ == '__main__':
     if parsed_args.debug:
         logging.basicConfig(level=logging.INFO)
 
-    DropboxLauncher().run()
+    is_autostarted = 'DESKTOP_AUTOSTART_ID' in os.environ
+    DropboxLauncher(silent=is_autostarted).run()


### PR DESCRIPTION
When the user has arranged for com.dropbox.Client.desktop to be symlinked
into ~/.config/autostart (by hand or with Tweaks), they probably want the
sync service to start when they log in, but they almost certainly don't
want the Dropbox folder to pop up when they log in.

gnome-session sets $DESKTOP_AUTOSTART_ID when launching .desktop files from
~/.config/autostart and other autostart locations. Detect this environment
variable, and don't display the Dropbox folder if it is set. When launched
normally from the desktop, continue to display the Dropbox folder (whether
or not the daemon was already running).

There are a couple of cleanup commits here too.

Fixes #9.