### PR TITLE
Enable StatusNotifierItem support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -98,9 +98,9 @@
                     "type": "extra-data",
                     "filename": "dropbox.tar.gz",
                     "only-arches": [ "x86_64" ],
-                    "url": "https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-60.4.107.tar.gz",
-                    "sha256": "5d275e6360bd1af62b9c784b3e05669187f1526b58231e22a28549da164a6a65",
-                    "size": 78742536,
+                    "url": "https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-61.4.95.tar.gz",
+                    "sha256": "087e8fbcc678ad58cecc7a7bbec185f043f59a27ff0212220e170730255da0b9",
+                    "size": 84694275,
                     "x-checker-data": {
                         "type": "rotating-url",
                         "url": "https://www.dropbox.com/download?plat=lnx.x86_64"

--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -98,9 +98,9 @@
                     "type": "extra-data",
                     "filename": "dropbox.tar.gz",
                     "only-arches": [ "x86_64" ],
-                    "url": "https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-59.4.93.tar.gz",
-                    "sha256": "ddced76c6096452b3219d2e06958dae1fb07466d11c046e384a7856e9ea5eb45",
-                    "size": 78361508,
+                    "url": "https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-60.4.107.tar.gz",
+                    "sha256": "5d275e6360bd1af62b9c784b3e05669187f1526b58231e22a28549da164a6a65",
+                    "size": 78742536,
                     "x-checker-data": {
                         "type": "rotating-url",
                         "url": "https://www.dropbox.com/download?plat=lnx.x86_64"

--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -14,9 +14,16 @@
         "--filesystem=home",
         "--filesystem=/tmp",
 	/* StatusNotifierItem support */
-	"--own-name=org.kde.*"
+	"--talk-name=org.kde.StatusNotifierWatcher",
+	/* Notification support */
+	"--talk-name=org.freedesktop.Notifications",
+	/* Accessibility */
+	"--talk-name=org.a11y.Bus",
+	/* GVFS */
+	"--talk-name=org.gtk.vfs.Daemon"
     ],
     "modules": [
+        "shared-modules/libappindicator/libappindicator-gtk3-12.10.json",
         {
             "name": "python3-psutil",
             "buildsystem": "simple",

--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -14,14 +14,7 @@
         "--filesystem=home",
         "--filesystem=/tmp",
 	/* StatusNotifierItem support */
-	"--talk-name=org.kde.StatusNotifierWatcher",
-	"--own-name=org.kde.StatusNotifierItem-7-1"
-        /* Note: the number 7 above is the PID of the dropboxd process
-         * when launched using the default command of this flatpak. It
-         * must be reviewed with every update. If the bus name
-         * org.kde.StatusNotifierItem-7-1 is already owned by another
-         * process, dropboxd will fail to show an indicator but it
-         * will not fall back to the XEMBED systray. */
+	"--own-name=org.kde.*"
     ],
     "modules": [
         {

--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -12,7 +12,16 @@
         "--socket=pulseaudio",
         "--share=network",
         "--filesystem=home",
-        "--filesystem=/tmp"
+        "--filesystem=/tmp",
+	/* StatusNotifierItem support */
+	"--talk-name=org.kde.StatusNotifierWatcher",
+	"--own-name=org.kde.StatusNotifierItem-7-1"
+        /* Note: the number 7 above is the PID of the dropboxd process
+         * when launched using the default command of this flatpak. It
+         * must be reviewed with every update. If the bus name
+         * org.kde.StatusNotifierItem-7-1 is already owned by another
+         * process, dropboxd will fail to show an indicator but it
+         * will not fall back to the XEMBED systray. */
     ],
     "modules": [
         {


### PR DESCRIPTION
Dropbox supports the StatusNotifierItem protocol to display its icon instead of using the deprecated systray icon. This patch enables SNI by adding the options `--talk-name=org.kde.StatusNotifierWatcher` and `--own-name=org.kde.StatusNotifierItem-7-1`.

In details, Dropbox must be able to communicate over D-Bus with `org.kde.StatusNotifierWatcher` and to own the bus name `org.kde.StatusNotifierItem-X-Y`, where X is the PID of the `dropboxd` process and Y is a unique number [1]. In this flatpak, X is always 7, and `dropboxd` uses 1 for Y as it shows only one indicator. I have added a reminder in the code that 7 should be reviewed whenever an update might produce a different PID for `dropboxd`.

Note however that the SNI support is fragile, not to mention only partially working (the Recently Changed Files menu is empty), and it should probably be reported to Dropbox: the choice of the name `org.kde.StatusNotifierItem-PID-1` assumes that the PID is unique across all processes, which is not true since the introduction of namespaces. Dropbox will fail to show an indicator if another process with PID 7 registers an indicator first. Other programs, such as Chromium and Electron apps, use a slightly different variation of the SNI protocol [2] which bypasses this problem entirely by not needing to own a name on the bus. Is there a way to request such a change to the Dropbox team?

[1] https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierItem/
[2] https://svn.reviewboard.kde.org/r/3587/