### PR TITLE
Roll back appdata to 85.4.155 properly

### DIFF
--- a/com.dropbox.Client.appdata.xml
+++ b/com.dropbox.Client.appdata.xml
@@ -58,8 +58,6 @@
 
   <releases>
     <release version="85.4.155" date="2019-11-14"/>
-    <release version="87.3.122" date="2019-11-26"/>
-    <release version="85.4.155" date="2019-11-14"/>
     <release version="84.4.170" date="2019-10-30"/>
     <release version="83.4.152" date="2019-10-15"/>
     <release version="82.4.155" date="2019-10-02"/>


### PR DESCRIPTION
f350ad1d10e660e31456546695959a96a6c66fb0 introduced invalid appdata due
to https://github.com/flathub/flatpak-external-data-checker/issues/36.

https://github.com/flathub/com.dropbox.Client/pull/69