### PR TITLE
Enable StatusNotifierItem support (attempt - 2)

### DIFF
--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -13,7 +13,10 @@
         "--socket=pulseaudio",
         "--share=network",
         "--filesystem=home",
-        "--filesystem=/tmp"
+        "--filesystem=/tmp",
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--own-name=org.kde.*"
     ],
     "modules": [
         {


### PR DESCRIPTION
Follow-up on discussion from #17, the tray-icon with AppIndicator[1]
as the shell extension works well if we allow it to own
DBus name(s) `org.kde.*`.
In my testing, the DBus requested name was always
`org.kde.StatusNotifierItem-7-1` on EndlessOS and
`org.kde.StatusNotifierItem-6-1` on Fedora. Hence, in order
to make it work for most of distributions, we need to let
it own `org.kde.*`.

[1] https://github.com/ubuntu/gnome-shell-extension-appindicator