### PR TITLE
Only launch file browser if daemon already running

### DIFF
--- a/dropbox-app.py
+++ b/dropbox-app.py
@@ -123,14 +123,13 @@ def get_dropbox_directory():
 
 
 class DropboxLauncher():
-    def __init__(self, silent):
+    def __init__(self):
         self._mainloop = GLib.MainLoop()
         self._config_monitor = None
         self._dir_monitor = None
         self._bus_owner_id = 0
         self._quit_if_name_lost = False
         self._launcher = None
-        self._silent = silent
 
     def run(self):
         self._try_own_bus_name()
@@ -189,10 +188,6 @@ class DropboxLauncher():
         sys.exit(retcode)
 
     def _open_dropbox_directory(self):
-        if self._silent:
-            logging.info("Autostarted; not opening Dropbox directory")
-            return
-
         directory = get_dropbox_directory()
         logging.info("Attempting to open Dropbox directory at {}...".format(directory))
 
@@ -213,10 +208,6 @@ class DropboxLauncher():
 
     def _launch_dropbox(self):
         self._disable_auto_updates()
-
-        if os.path.exists(os.path.expanduser(DROPBOX_CONFIG)):
-            self._open_dropbox_directory()
-
         self._launch_dropbox_daemon()
 
     def _disable_auto_updates(self):
@@ -294,8 +285,7 @@ def main():
     if parsed_args.debug:
         logging.basicConfig(level=logging.INFO)
 
-    is_autostarted = 'DESKTOP_AUTOSTART_ID' in os.environ
-    DropboxLauncher(silent=is_autostarted).run()
+    DropboxLauncher().run()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Previously, launching the Flatpak would open the Dropbox folder in a
file browser, except if autostarted by gnome-session.

The upstream behaviour is to just open a tray icon. The rationale for
opening the file browser was to avoid user confusion: why would clicking
the Dropbox icon not show any visible feedback, except an easily-missed
16×16 tray icon? There are also systems that don't support tray icons at
all.

However, as seen by #8 and #93, autostart being noisy on non-GNOME
desktops is annoying. There does not seem to be a straightforward way to
detect whether one is being autostarted on other desktops (or at least
no-one has pointed to one).

As a compromise, only open a file browser if the Dropbox daemon was
already running. This leads to the following behaviours:

- If the .desktop file is symlinked into `~/.config/autostart`:
  - login: no file browser, tray icon appears if supported
  - click launcher: file browser (assuming Dropbox didn't quit in the
    meantime)
- Otherwise:
  - click launcher: no file browser, tray icon appears if supported
  - click launcher again: file browser (assuming Dropbox didn't quit in
    the meantime)