### PR TITLE
Don't try to preserve owner/permissions when extracting tarball

### DIFF
--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -112,7 +112,7 @@
                     "type": "script",
                     "dest-filename": "apply_extra",
                     "commands": [
-                        "tar xf dropbox.tar.gz",
+                        "tar -xf --no-same-owner --no-same-permissions dropbox.tar.gz",
                         "rm -f dropbox.tar.gz",
                         "chmod a+xr ."
                     ]


### PR DESCRIPTION
When run as root, `tar` defaults to `--same-owner --same-permissions`.
This is reported to cause many errors:

    tar: .dropbox-dist/VERSION: Cannot change ownership to uid 1000, gid 1000: Operation not permitted
    ...
    tar: Exiting with failure status due to previous errors

While this does not actually cause the apply_extra script to fail, it is
ugly!

Fixes #122