### PR TITLE
Update external data checker annotations

### DIFF
--- a/com.dropbox.Client.appdata.xml
+++ b/com.dropbox.Client.appdata.xml
@@ -58,6 +58,7 @@
   <description><p>Need to safely store all of your important documents, photos, songs, and files? Easy! With this app you can use the internet to save everything that’s important to you. You can then access those files from any computer that has an internet connection. Use this service to backup your files, share photos or collaborate on a project by sharing a Dropbox folder with whomever you’d like. Create a free account and start saving and sharing today!  ** Requires internet.</p><p>NOTE: This wrapper is not verified by, affiliated with, or supported by Dropbox, Inc.</p></description>
 
   <releases>
+    <release version="115.4.601" date="2021-02-03"/>
     <release version="113.4.507" date="2021-01-14"/>
     <release version="112.4.321" date="2020-12-15"/>
     <release version="111.4.472" date="2020-12-01"/>

--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -108,6 +108,7 @@
                     "sha256": "197c080bd67399c57b9c3a8deefdc4c4e74851324cf7d52d4d668fb45cebb545",
                     "size": 103671827,
                     "x-checker-data": {
+                        "is-main-source": true,
                         "type": "html",
                         "url": "https://www.dropboxforum.com/t5/forums/filteredbylabelpage/board-id/101003016/label-name/stable%20build",
                         "version-pattern": "Stable Build (\\d+.\\d+.\\d+)",

--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -26,7 +26,12 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/giampaolo/psutil/archive/release-5.4.5.tar.gz",
-                    "sha256": "5bf25eff39ba5ba1d00dc94d114012d11b7a6ace62d98943897097d117e0a3f6"
+                    "sha256": "5bf25eff39ba5ba1d00dc94d114012d11b7a6ace62d98943897097d117e0a3f6",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 3978,
+                        "url-template": "https://github.com/giampaolo/psutil/archive/release-$version.tar.gz"
+                    }
                 }
             ],
             "build-commands": [

--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -108,9 +108,10 @@
                     "sha256": "197c080bd67399c57b9c3a8deefdc4c4e74851324cf7d52d4d668fb45cebb545",
                     "size": 103671827,
                     "x-checker-data": {
-                        "type": "rotating-url",
-                        "url": "https://www.dropbox.com/download?plat=lnx.x86_64",
-                        "pattern": "https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-([0-9.]+).tar.gz"
+                        "type": "html",
+                        "url": "https://www.dropboxforum.com/t5/forums/filteredbylabelpage/board-id/101003016/label-name/stable%20build",
+                        "version-pattern": "Stable Build (\\d+.\\d+.\\d+)",
+                        "url-template": "https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-$version.tar.gz"
                     }
                 },
                 {

--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -25,8 +25,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/giampaolo/psutil/archive/release-5.4.5.tar.gz",
-                    "sha256": "5bf25eff39ba5ba1d00dc94d114012d11b7a6ace62d98943897097d117e0a3f6",
+                    "url": "https://github.com/giampaolo/psutil/archive/release-5.8.0.tar.gz",
+                    "sha256": "c015248da36109ffaa15f46fce8c0003f678cfaa408090f466c80318885e7abf",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 3978,
@@ -104,9 +104,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-113.4.507.tar.gz",
-                    "sha256": "197c080bd67399c57b9c3a8deefdc4c4e74851324cf7d52d4d668fb45cebb545",
-                    "size": 103671827,
+                    "url": "https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-115.4.601.tar.gz",
+                    "sha256": "efa6490cf905e69fec96c2abbd384bc5d16b13256a2480a2da8a4d38214f12aa",
+                    "size": 103710196,
                     "x-checker-data": {
                         "is-main-source": true,
                         "type": "html",


### PR DESCRIPTION
- Add checking for psutil
- Switch to scraping Dropbox release announcements
- Add `is-main-source` annotation
- Update Dropbox while we're here