### PR TITLE
Set custom carousel tile background colour in GNOME Software

### DIFF
--- a/com.dropbox.Client.appdata.xml
+++ b/com.dropbox.Client.appdata.xml
@@ -132,6 +132,10 @@
     </screenshot>
   </screenshots>
 
+  <custom>
+    <value key="GnomeSoftware::key-colors">[(20, 200, 235)]</value>
+  </custom>
+
   <content_rating type="oars-1.0">
     <content_attribute id="social-chat">moderate</content_attribute>
     <content_attribute id="money-purchasing">intense</content_attribute>


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/gnome-software/-/wikis/software-metadata#user-content-how-to-set-the-carousel-tile-background-colour

Currently the colors of the icon and the background do not have enough contrast, this change sets the background to white. I have not been able to test it locally.
![imagen](https://user-images.githubusercontent.com/42654671/150172038-40f6716b-c9d9-472e-9dbc-fb4500d3cca8.png)