### PR TITLE
Install psutil as a bare package, not an egg

### DIFF
--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -33,7 +33,7 @@
             ],
             "build-commands": [
                 "python3 setup.py build",
-                "python3 setup.py install --prefix /app"
+                "python3 setup.py install --single-version-externally-managed --root / --prefix /app"
             ],
             "cleanup": [
                 "tests",


### PR DESCRIPTION
For reasons I do not understand, from
52263f51c1e4000984a2601b8b6939bfb0d5adf8 ("Update to GNOME 43 runtime") Python would fail to find the psutil module at runtime:

    Traceback (most recent call last):
      File "/app/bin/dropbox-app", line 28, in <module>
        import psutil
    ModuleNotFoundError: No module named 'psutil'

By default, the module is installed to the following directory:

    /app/lib/python3.9/site-packages/psutil-5.9.2-py3.9-linux-x86_64.egg

With these build flags, it is instead installed to:

    /app/lib/python3.10/site-packages/psutil

and Python can find it at runtime.

Fixes https://github.com/flathub/com.dropbox.Client/issues/282