### PR TITLE
fixed permission on ".dropbox-dist" folder causing issues with backup…

### DIFF
--- a/dropbox-app.py
+++ b/dropbox-app.py
@@ -227,7 +227,7 @@ class DropboxLauncher():
             shutil.move(orig_dir, backup_dir)
 
         logging.info("Disabling auto-updates by making {} unwritable".format(orig_dir))
-        os.mkdir(orig_dir, mode=0)
+        os.mkdir(orig_dir, mode=0o400)
 
     def _launch_dropbox_daemon(self):
         logging.info("Running Dropbox's launcher at {}...".format(DROPBOX_LAUNCHER))


### PR DESCRIPTION
… software

By creating the folder with mode=0o400 we preserve read only access and auto updater should remain disabled.

Still, backup software like DéjàDup do not complain about it anymore because they can read it/back it up.