### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -12,8 +12,7 @@
         "--filesystem=home",
         "--filesystem=/tmp",
         "--talk-name=org.freedesktop.Notifications",
-        "--talk-name=org.kde.StatusNotifierWatcher",
-        "--own-name=org.kde.*"
+        "--talk-name=org.kde.StatusNotifierWatcher"
     ],
     "modules": [
         {


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/66#issuecomment-1386033025

Fixes #111 