### PR TITLE
Configure fedc to only open PRs for Dropbox updates

### DIFF
--- a/com.dropbox.Client.appdata.xml
+++ b/com.dropbox.Client.appdata.xml
@@ -58,6 +58,7 @@
   <description><p>Need to safely store all of your important documents, photos, songs, and files? Easy! With this app you can use the internet to save everything that’s important to you. You can then access those files from any computer that has an internet connection. Use this service to backup your files, share photos or collaborate on a project by sharing a Dropbox folder with whomever you’d like. Create a free account and start saving and sharing today!  ** Requires internet.</p><p>NOTE: This wrapper is not verified by, affiliated with, or supported by Dropbox, Inc.</p></description>
 
   <releases>
+    <release version="191.4.4995" date="2024-01-23"/>
     <release version="190.4.6383" date="2024-01-08"/>
     <release version="189.4.8427" date="2024-01-04"/>
     <release version="189.4.8395" date="2023-12-18"/>

--- a/com.dropbox.Client.json
+++ b/com.dropbox.Client.json
@@ -22,8 +22,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/giampaolo/psutil/archive/release-5.9.7.tar.gz",
-                    "sha256": "2af131e80aafc0694c4f2ab3215f0fca6e39bdf94ca5a88c50e5843a0078f3c6",
+                    "url": "https://github.com/giampaolo/psutil/archive/release-5.9.8.tar.gz",
+                    "sha256": "962fbb077209fda6416046b704b51ed17a61edde41a4573886640026e2c53bae",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 3978,
@@ -52,8 +52,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/dropbox/nautilus-dropbox.git",
-                    "commit": "89b9a4bfe07007749b6ef5fbfcd68272516390f9",
-                    "tag": "v2023.09.06",
+                    "commit": "a7e132a56fec9d7f48ee25788fba5e45c0e0b0fc",
+                    "tag": "v2024.01.22",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/dropbox/nautilus-dropbox/tags",
@@ -102,9 +102,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-190.4.6383.tar.gz",
-                    "sha256": "333974775fda6e6834aea9c94bf07a86d928eebfda86c1e3f49c3085a2b3c80b",
-                    "size": 115387950,
+                    "url": "https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x86_64-191.4.4995.tar.gz",
+                    "sha256": "3abfdf01c61102e364c9738fb705dc5304c89e1fbb98a7b0ca1dc871f490e336",
+                    "size": 115356260,
                     "x-checker-data": {
                         "is-main-source": true,
                         "type": "html",

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
     "only-arches": ["x86_64"],
+    "require-important-update": true,
     "automerge-flathubbot-prs": false
 }


### PR DESCRIPTION
nautilus-dropbox is only used for the Dropbox icon; and the use of psutil is very minimal. Dropbox itself releases quite regularly, so only open PRs for versions of Dropbox itself (plus any other module updates pending at the time).